### PR TITLE
WIP: adding support for EventKind::SignatureRequest (NIP-70)

### DIFF
--- a/crates/nostr/examples/sign_and_return.rs
+++ b/crates/nostr/examples/sign_and_return.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 Paul Miller
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Distributed under the MIT software license
+
+use bitcoin_hashes::sha256::Hash as Sha256Hash;
+use bitcoin_hashes::Hash;
+use std::str::FromStr;
+
+use nostr::secp256k1::SecretKey;
+use nostr::Timestamp;
+use nostr::SECP256K1;
+use nostr::{
+    event::EventBuilder, event::Marker, ClientMessage, Filter, Keys, Kind, RelayMessage, Result, SubscriptionId,
+    Tag,
+};
+use tungstenite::{connect, Message as WsMessage};
+// use secp256k1;
+
+const ALICE_SK: &str = "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97";
+const BOB_SK: &str = "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e";
+// const WS_ENDPOINT: &str = "wss://relayer.fiatjaf.com/";
+const WS_ENDPOINT: &str = "wss://r1.hashed.systems";
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let (mut socket, _response) = connect(WS_ENDPOINT).expect("Can't connect");
+
+    let bob_keys = Keys::new(SecretKey::from_str(BOB_SK)?);
+    let alice_keys = Keys::new(SecretKey::from_str(ALICE_SK)?);
+
+    let subscribe_to_bob = ClientMessage::new_req(
+        SubscriptionId::new("wait-for-signature-request"),
+        vec![Filter::new()
+            .authors(vec![bob_keys.public_key()])
+            .since(Timestamp::now())
+            // subscribe to Signature Requests, NIP-70, Kind=9999 (WIP)
+            .kind(Kind::SignatureRequest),
+        ],
+            // .kind(Kind::TextNote)],
+    );
+
+    socket.write_message(WsMessage::Text(subscribe_to_bob.as_json()))?;
+
+    loop {
+        let msg = socket.read_message().expect("Error reading message");
+        let msg_text = msg.to_text().expect("Failed to conver message to text");
+        if let Ok(handled_message) = RelayMessage::from_json(msg_text) {
+            match handled_message {
+                RelayMessage::Notice { message } => {
+                    println!("Got a notice: {}", message);
+                }
+                RelayMessage::Event {
+                    event: e,
+                    subscription_id: _,
+                } => {
+                    println!("Got an event  : {:#?} ", e);
+
+                    if e.kind == Kind::SignatureRequest {
+                        println!("Payload to sign   : {}", e.content);
+                        let raw_payload_to_sign = e.content.as_bytes();
+                        println!("Raw payload to sign   : {:?}", raw_payload_to_sign);
+    
+                        // hash the message
+                        let hashed_message = Sha256Hash::hash(raw_payload_to_sign);
+                        println!("Hashed message   : {:#?}", hashed_message);
+    
+                        let payload_to_sign = secp256k1::Message::from_slice(&hashed_message)?;
+    
+                        const MEMO: &str = "sgtm";
+    
+                        let tag_original_request = Tag::Event(
+                            e.id,
+                            Some("wss://r1.hashed.systems".to_string()),
+                            Some(Marker::Reply),
+                        );
+    
+                        let tag_bob_in_reply =
+                            Tag::PubKey(e.pubkey, Some("wss://r1.hashed.systems".to_string()));
+    
+                        let signature =
+                            SECP256K1.sign_schnorr(&payload_to_sign, &alice_keys.key_pair()?);
+                        let alice_signs_the_message_and_responds = ClientMessage::new_event(
+                            EventBuilder::new_signature_response(
+                                signature,
+                                Some(MEMO.to_string()),
+                                &[tag_original_request, tag_bob_in_reply],
+                            )
+                            .to_event(&alice_keys)?,
+                        );
+    
+                        println!("Signature : {}", signature.to_string());
+    
+                        socket.write_message(WsMessage::Text(alice_signs_the_message_and_responds.as_json()))?;
+                        let msg = socket.read_message().expect("Error reading message");
+                        let msg_text = msg.to_text().expect("Failed to convert message to text");
+                    
+                        println!("REPLY    : {:#?}", msg_text);
+                    }                    
+                }
+                RelayMessage::EndOfStoredEvents(_subscription_id) => {
+                    println!("Relay signalled End of Stored Events");
+                }
+                RelayMessage::Ok {
+                    event_id,
+                    status,
+                    message,
+                } => {
+                    println!("Got OK message: {} - {} - {}", event_id, status, message);
+                }
+                RelayMessage::Auth { challenge } => {
+                    println!("Got a auth challenge: {}", challenge);
+                }
+                RelayMessage::Empty => {
+                    println!("Empty message");
+                }
+            }
+        } else {
+            println!("Got unexpected message: {}", msg_text);
+        }
+    }
+}

--- a/crates/nostr/examples/sigrequest.rs
+++ b/crates/nostr/examples/sigrequest.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Paul Miller
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Distributed under the MIT software license
+
+use std::str::FromStr;
+
+use nostr::secp256k1::SecretKey;
+use nostr::{
+    ClientMessage, EventBuilder, Keys, Result, Tag,
+};
+use tungstenite::{connect, Message as WsMessage};
+
+const ALICE_SK: &str = "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97";
+const BOB_SK: &str = "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e";
+// const WS_ENDPOINT: &str = "wss://relayer.fiatjaf.com/";
+const WS_ENDPOINT: &str = "wss://r1.hashed.systems";
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let (mut socket, _response) = connect(WS_ENDPOINT).expect("Can't connect");
+
+    let alice_keys = Keys::new(SecretKey::from_str(ALICE_SK)?);
+    let bob_keys = Keys::new(SecretKey::from_str(BOB_SK)?);
+
+    let bob_tags_alice = Tag::PubKey(alice_keys.public_key(), Some(WS_ENDPOINT.to_string()));
+
+    const PAYLOAD_REQUEST: &str = "I hereby approve of eating the filet tonight";
+    const MEMO: &str = "please approve this because I already started the grill";
+    let bob_asks_alice_to_sign = ClientMessage::new_event(
+        EventBuilder::new_signature_request(PAYLOAD_REQUEST,Some(MEMO.to_string()),&[bob_tags_alice]).to_event(&bob_keys)?,
+    );
+
+    socket.write_message(WsMessage::Text(bob_asks_alice_to_sign.as_json()))?;
+    let msg = socket.read_message().expect("Error reading message");
+    let msg_text = msg.to_text().expect("Failed to convert message to text");
+
+    println!("REPLY    : {:#?}", msg_text);
+    Ok(())
+}

--- a/crates/nostr/examples/sigrequest_and_handle_reply.rs
+++ b/crates/nostr/examples/sigrequest_and_handle_reply.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2021 Paul Miller
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Distributed under the MIT software license\
+
+use nostr::Timestamp;
+use nostr::{
+    event::EventBuilder, ClientMessage, Filter, Keys, Kind, RelayMessage, Result, SubscriptionId,
+    Tag,
+};
+use std::str::FromStr;
+use nostr::secp256k1::SecretKey;
+use tungstenite::{connect, Message as WsMessage};
+
+const ALICE_SK: &str = "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97";
+const BOB_SK: &str = "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e";
+// const WS_ENDPOINT: &str = "wss://relayer.fiatjaf.com/";
+const WS_ENDPOINT: &str = "wss://r1.hashed.systems";
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let timestamp = Timestamp::now() - std::time::Duration::new(5, 0); // go back 5 seconds
+
+    let (mut socket, _response) = connect(WS_ENDPOINT).expect("Can't connect");
+
+    let alice_keys = Keys::new(SecretKey::from_str(ALICE_SK)?);
+    let bob_keys = Keys::new(SecretKey::from_str(BOB_SK)?);
+
+    let bob_tags_alice = Tag::PubKey(alice_keys.public_key(), Some(WS_ENDPOINT.to_string()));
+
+    const PAYLOAD_REQUEST: &str = "I hereby approve of eating the filet tonight";
+    const MEMO: &str = "please approve this because I already started the grill";
+    let bob_asks_alice_to_sign = ClientMessage::new_event(
+        EventBuilder::new_signature_request(PAYLOAD_REQUEST,Some(MEMO.to_string()),&[bob_tags_alice]).to_event(&bob_keys)?,
+    );
+
+    socket.write_message(WsMessage::Text(bob_asks_alice_to_sign.as_json()))?;
+    let msg = socket.read_message().expect("Error reading message");
+    let msg_text = msg.to_text().expect("Failed to convert message to text");
+
+    println!("Server reply    : {:#?}", msg_text);
+
+    // setup subscription to wait for Alice's reply
+    // TODO: can I filter to only replies to the SignatureRequest precisely
+    let subscribe_to_alice = ClientMessage::new_req(
+        SubscriptionId::new("wait-for-signed-response"),
+        vec![Filter::new()
+            .authors(vec![alice_keys.public_key()])
+            .since(timestamp)
+            // subscribe to Signature Requests, NIP-70, Kind=9999 (WIP)
+            // .kind(Kind::SignatureResponse)
+        ],
+    );
+
+    socket.write_message(WsMessage::Text(subscribe_to_alice.as_json()))?;
+
+    loop {
+        let msg = socket.read_message().expect("Error reading message");
+        let msg_text = msg.to_text().expect("Failed to conver message to text");
+        println!("MESSAGE : {:#?}", msg_text);
+        if let Ok(handled_message) = RelayMessage::from_json(msg_text) {
+            match handled_message {
+                RelayMessage::Notice { message } => {
+                    println!("Got a notice: {}", message);
+                }
+                RelayMessage::Event {
+                    event: e,
+                    subscription_id: _,
+                } => {
+                    println!("Got an event  : {:#?} ", e);
+
+                    if e.kind == Kind::SignatureResponse {
+                        println!("Find the signature and verify it");
+                    }
+                }
+                RelayMessage::EndOfStoredEvents(_subscription_id) => {
+                    println!("Relay signalled End of Stored Events");
+                }
+                RelayMessage::Ok {
+                    event_id,
+                    status,
+                    message,
+                } => {
+                    println!("Got OK message: {} - {} - {}", event_id, status, message);
+                }
+                RelayMessage::Auth { challenge } => {
+                    println!("Got a auth challenge: {}", challenge);
+                }
+                RelayMessage::Empty => {
+                    println!("Empty message");
+                }
+            }
+        } else {
+            println!("Got unexpected message: {}", msg_text);
+        }
+    }
+}

--- a/crates/nostr/examples/subscribe.rs
+++ b/crates/nostr/examples/subscribe.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Paul Miller
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Distributed under the MIT software license
+
+use std::str::FromStr;
+
+use nostr::secp256k1::SecretKey;
+use nostr::{
+    ClientMessage, Filter, Keys, Kind, RelayMessage, Result, SubscriptionId,
+};
+use tungstenite::{connect, Message as WsMessage};
+
+const _ALICE_SK: &str = "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97";
+const BOB_SK: &str = "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e";
+// const WS_ENDPOINT: &str = "wss://relayer.fiatjaf.com/";
+const WS_ENDPOINT: &str = "wss://r1.hashed.systems";
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let (mut socket, _response) = connect(WS_ENDPOINT).expect("Can't connect");
+
+    let bob_keys = Keys::new(SecretKey::from_str(BOB_SK)?);
+
+    let subscribe_to_bob = ClientMessage::new_req(
+        SubscriptionId::new("abcdefgh"),
+        vec![Filter::new()
+            .authors(vec![bob_keys.public_key()])
+            // subscribe to Signature Requests, NIP-70, Kind=9999 (WIP)
+            .kind(Kind::SignatureRequest)],
+    );
+
+    socket.write_message(WsMessage::Text(subscribe_to_bob.as_json()))?;
+
+    loop {
+        let msg = socket.read_message().expect("Error reading message");
+        let msg_text = msg.to_text().expect("Failed to conver message to text");
+        println!("MESSAGE : {:#?}", msg_text);
+        if let Ok(handled_message) = RelayMessage::from_json(msg_text) {
+            match handled_message {
+                RelayMessage::Notice { message } => {
+                    println!("Got a notice: {}", message);
+                }
+                RelayMessage::Event {
+                    event: e,
+                    subscription_id: _,
+                } => {
+                    println!("Got an event  : {:#?} ", e);
+                }
+                RelayMessage::EndOfStoredEvents(_subscription_id) => {
+                    println!("Relay signalled End of Stored Events");
+                }
+                RelayMessage::Ok {
+                    event_id,
+                    status,
+                    message,
+                } => {
+                    println!("Got OK message: {} - {} - {}", event_id, status, message);
+                }
+                RelayMessage::Auth { challenge } => {
+                    println!("Got a auth challenge: {}", challenge);
+                }
+                RelayMessage::Empty => {
+                    println!("Empty message");
+                }
+            }
+        } else {
+            println!("Got unexpected message: {}", msg_text);
+        }
+    }
+}

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -175,6 +175,24 @@ impl EventBuilder {
         Self::new(Kind::TextNote, content, tags)
     }
 
+    /// Signature request
+    ///
+    /// TBD: NIP-70 <https://github.com/nostr-protocol/nips/blob/master/01.md>
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use nostr::EventBuilder;
+    ///
+    /// let builder = EventBuilder::new_signature_request("Sign this payload", &[]);
+    /// ```
+    pub fn new_signature_request<S>(content: S, tags: &[Tag]) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::new(Kind::SignatureRequest, content, tags)
+    }
+
+
     /// Long-form text note (generally referred to as "articles" or "blog posts").
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/23.md>
@@ -398,6 +416,22 @@ mod tests {
         )?);
 
         let event = EventBuilder::new_text_note("hello", &vec![]).to_event(&keys)?;
+
+        let serialized = event.as_json();
+        let deserialized = Event::from_json(serialized)?;
+
+        assert_eq!(event, deserialized);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_signature_request() -> Result<()> {
+        let keys = Keys::new(SecretKey::from_str(
+            "6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e",
+        )?);
+
+        let event = EventBuilder::new_signature_request("<payload>", &vec![]).to_event(&keys)?;
 
         let serialized = event.as_json();
         let deserialized = Event::from_json(serialized)?;

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -183,7 +183,7 @@ impl EventBuilder {
     /// ```rust,no_run
     /// use nostr::EventBuilder;
     ///
-    /// let builder = EventBuilder::new_signature_request("Sign this payload", Some("Here is supporting memo"), &[]);
+    /// let builder = EventBuilder::new_signature_request("Sign this payload", Some("Here is supporting memo".to_string()), &[]);
     /// ```
     pub fn new_signature_request<S>(to_sign: S, content: Option<String>, tags: &[Tag]) -> Self
     where
@@ -200,9 +200,18 @@ impl EventBuilder {
     /// # Example
     /// ```rust,no_run
     /// use nostr::EventBuilder;
-    ///
-    /// let signature = SECP256K1.sign_schnorr(&payload_to_sign, &alice_keys.key_pair()?);
-    /// let builder = EventBuilder::new_signature_response("signature", Some("Optional memo"), &[]);
+    /// use nostr::SECP256K1;
+    /// use bitcoin_hashes::sha256::Hash as Sha256Hash;
+    /// use bitcoin_hashes::Hash;
+    /// use std::str::FromStr;
+    /// 
+    /// const ALICE_SK: &str = "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97";
+    /// let alice_keys = nostr::Keys::new(secp256k1::SecretKey::from_str(ALICE_SK).unwrap());
+    /// let raw_payload_to_sign = "payload to sign".as_bytes();
+    /// let hashed_payload = Sha256Hash::hash(raw_payload_to_sign);
+    /// let message = secp256k1::Message::from_slice(&hashed_payload).unwrap();
+    /// let signature = SECP256K1.sign_schnorr(&message, &alice_keys.key_pair().unwrap());
+    /// let builder = EventBuilder::new_signature_response(signature, Some("Optional memo".to_string()), &[]);
     /// ```
     pub fn new_signature_response(signature: Signature, content: Option<String>, tags: &[Tag]) -> Self
     {

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -63,8 +63,10 @@ pub enum Kind {
     Replaceable(u16),
     /// Ephemeral event (must be between 20000 and <30000)
     Ephemeral(u16),
-    /// Ephemeral event sent from one account to another requesting a signature of the event's content
+    /// Ephemeral (?) event sent from one account to another requesting a signature of the event's content
     SignatureRequest,
+    /// Ephemeral (?) event sent as a reply to a SignatureRequest type
+    SignatureResponse,
     /// Parameterized Replacabe event (must be between 30000 and <40000)
     ParameterizedReplaceable(u16),
     /// Custom
@@ -107,7 +109,8 @@ impl From<u64> for Kind {
             1984 => Self::Reporting,
             9734 => Self::ZapRequest,
             9735 => Self::Zap,
-            9999 => Self::SignatureRequest,
+            9991 => Self::SignatureRequest,
+            9992 => Self::SignatureResponse,
             22242 => Self::Authentication,
             30023 => Self::LongFormTextNote,
             x if (10_000..20_000).contains(&x) => Self::Replaceable(x as u16),
@@ -143,7 +146,8 @@ impl From<Kind> for u64 {
             Kind::ZapRequest => 9734,
             Kind::Zap => 9735,
             Kind::Authentication => 22242,
-            Kind::SignatureRequest => 9999,
+            Kind::SignatureRequest => 9991,
+            Kind::SignatureResponse => 9992,
             Kind::LongFormTextNote => 30023,
             Kind::Replaceable(u) => u as u64,
             Kind::Ephemeral(u) => u as u64,

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -63,6 +63,8 @@ pub enum Kind {
     Replaceable(u16),
     /// Ephemeral event (must be between 20000 and <30000)
     Ephemeral(u16),
+    /// Ephemeral event sent from one account to another requesting a signature of the event's content
+    SignatureRequest,
     /// Parameterized Replacabe event (must be between 30000 and <40000)
     ParameterizedReplaceable(u16),
     /// Custom
@@ -105,6 +107,7 @@ impl From<u64> for Kind {
             1984 => Self::Reporting,
             9734 => Self::ZapRequest,
             9735 => Self::Zap,
+            9999 => Self::SignatureRequest,
             22242 => Self::Authentication,
             30023 => Self::LongFormTextNote,
             x if (10_000..20_000).contains(&x) => Self::Replaceable(x as u16),
@@ -140,6 +143,7 @@ impl From<Kind> for u64 {
             Kind::ZapRequest => 9734,
             Kind::Zap => 9735,
             Kind::Authentication => 22242,
+            Kind::SignatureRequest => 9999,
             Kind::LongFormTextNote => 30023,
             Kind::Replaceable(u) => u as u64,
             Kind::Ephemeral(u) => u as u64,

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -154,4 +154,21 @@ mod tests {
         assert_eq!(Kind::Custom(123), e.kind);
         assert_eq!(Kind::Custom(123), deserialized.kind);
     }
+
+    #[test]
+    fn test_signature_request() {
+        let keys = Keys::generate();
+        let e: Event = EventBuilder::new(Kind::SignatureRequest, "my content", &[])
+            .to_event(&keys)
+            .unwrap();
+
+        let serialized = e.as_json();
+        let deserialized = Event::from_json(serialized.clone()).unwrap();
+
+        println!("Event : {}", serialized.clone());
+
+        assert_eq!(e, deserialized);
+        assert_eq!(Kind::SignatureRequest, e.kind);
+        assert_eq!(Kind::SignatureRequest, deserialized.kind);
+    }
 }

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -853,7 +853,7 @@ mod tests {
 
         assert_eq!(
             Tag::parse(vec!["to_sign", "payload to sign"])?,
-            Tag::Subject(String::from("payload to sign"))
+            Tag::ToSignPayload(String::from("payload to sign"))
         );
 
         // @TODO: Add test for Signature Tag 

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 
 use secp256k1::schnorr::Signature;
 use secp256k1::XOnlyPublicKey;
+// use secp256k1::schnorrsig::Signature;
 use serde::de::Error as DeserializerError;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -166,6 +167,10 @@ pub enum TagKind {
     Summary,
     /// PublishedAt (NIP23)
     PublishedAt,
+    /// Payload requesting to be signed (NIP70, kind 9991)
+    ToSignPayload,
+    /// Signature reply (NIP70, kind 9992)
+    Signature,
     /// Custom tag kind
     Custom(String),
 }
@@ -191,6 +196,8 @@ impl fmt::Display for TagKind {
             Self::Image => write!(f, "image"),
             Self::Summary => write!(f, "summary"),
             Self::PublishedAt => write!(f, "published_at"),
+            Self::ToSignPayload => write!(f, "to_sign"),
+            Self::Signature => write!(f, "signature"),
             Self::Custom(tag) => write!(f, "{tag}"),
         }
     }
@@ -221,6 +228,8 @@ where
             "image" => Self::Image,
             "summary" => Self::Summary,
             "published_at" => Self::PublishedAt,
+            "signature" => Self::Signature,
+            "to_sign" => Self::ToSignPayload,
             tag => Self::Custom(tag.to_string()),
         }
     }
@@ -269,6 +278,8 @@ pub enum Tag {
     Image(String),
     Summary(String),
     PublishedAt(Timestamp),
+    ToSignPayload(String),
+    Signature(Signature),
 }
 
 impl Tag {
@@ -325,6 +336,8 @@ where
                 TagKind::Image => Ok(Self::Image(content.to_string())),
                 TagKind::Summary => Ok(Self::Summary(content.to_string())),
                 TagKind::PublishedAt => Ok(Self::PublishedAt(Timestamp::from_str(content)?)),
+                TagKind::Signature => Ok(Self::Signature(Signature::from_slice(content.as_bytes())?)),
+                TagKind::ToSignPayload => Ok(Self::ToSignPayload(content.to_string())),
                 _ => Ok(Self::Generic(tag_kind, vec![content.to_string()])),
             }
         } else if tag_len == 3 {
@@ -480,6 +493,8 @@ impl From<Tag> for Vec<String> {
             Tag::Title(title) => vec![TagKind::Title.to_string(), title],
             Tag::Image(image) => vec![TagKind::Image.to_string(), image],
             Tag::Summary(summary) => vec![TagKind::Summary.to_string(), summary],
+            Tag::Signature(signature) => vec![TagKind::Signature.to_string(), signature.to_string()],
+            Tag::ToSignPayload(to_sign) => vec![TagKind::ToSignPayload.to_string(), to_sign],
             Tag::PublishedAt(timestamp) => {
                 vec![TagKind::PublishedAt.to_string(), timestamp.to_string()]
             }
@@ -835,6 +850,13 @@ mod tests {
             Tag::parse(vec!["subject", "textnote with subject"])?,
             Tag::Subject(String::from("textnote with subject"))
         );
+
+        assert_eq!(
+            Tag::parse(vec!["to_sign", "payload to sign"])?,
+            Tag::Subject(String::from("payload to sign"))
+        );
+
+        // @TODO: Add test for Signature Tag 
 
         assert_eq!(
             Tag::parse(vec!["client", "nostr-sdk"])?,


### PR DESCRIPTION
### Description
This PR will implement [NIP-70](https://github.com/3yekn/nips/blob/master/70.md) as it moves farther along in design. 

For now, it implements as EventKind `9999` but more research is needed on the Kinds. 

I created an example that publishes the Signature Request, but not yet an full circle example where the payload is signed by the recipient. 

I also need to update the NIP with how signatures are returned, although I think a normal reply with the signature as the content is enough.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [ ] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [ ] I ran `make precommit` before committing